### PR TITLE
AF-3736: Fix The 'componentType' configuration parameter is required for the 'sitemap' component error

### DIFF
--- a/view/adminhtml/ui_component/catalogstaging_category_update_form.xml
+++ b/view/adminhtml/ui_component/catalogstaging_category_update_form.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
+    <fieldset name="sitemap" sortOrder="25">
+        <settings>
+            <collapsible>true</collapsible>
+            <label translate="true">Sitemap</label>
+        </settings>
+        <field name="show_in_sitemap" sortOrder="10" formElement="checkbox">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="source" xsi:type="string">category</item>
+                    <item name="default" xsi:type="number">1</item>
+                </item>
+            </argument>
+            <settings>
+                <validation>
+                    <rule name="required-entry" xsi:type="boolean">false</rule>
+                </validation>
+                <dataType>boolean</dataType>
+                <label translate="true">Show in Sitemap</label>
+            </settings>
+            <formElements>
+                <checkbox>
+                    <settings>
+                        <valueMap>
+                            <map name="false" xsi:type="string">0</map>
+                            <map name="true" xsi:type="string">1</map>
+                        </valueMap>
+                        <prefer>toggle</prefer>
+                    </settings>
+                </checkbox>
+            </formElements>
+        </field>
+    </fieldset>
+</form>


### PR DESCRIPTION
**Description of the proposed changes**
This PR content following fix.
- Fix for below error if we schedule admin category page.
`The 'componentType' configuration parameter is required for the 'sitemap' component`

**Screenshots**
Before issue fix
![Screenshot from 2025-03-19 11-52-01](https://github.com/user-attachments/assets/55ba4fd4-87b5-48fa-80d4-abf03f9fa95e)

After issue fix
![Screenshot from 2025-03-19 12-07-08](https://github.com/user-attachments/assets/485a64a3-c6cd-4b07-ac87-90695a629b0d)


**Notes to reviewers**
N/A

**Time tracking**
AF-3736: Code Review